### PR TITLE
Fix: 아티스트 페이지의 앨범 및 싱글 섹션에서 이미지 사이즈를 md로 설정하도록 변경

### DIFF
--- a/src/features/artist/components/AlbumList.tsx
+++ b/src/features/artist/components/AlbumList.tsx
@@ -19,7 +19,7 @@ export const AlbumList = ({ albums }: AlbumListProps) => {
             <Link href={`/album/${album.id}`} className="group">
               <div className="relative aspect-square bg-card-bg rounded-sm overflow-hidden">
                 <UnoptimizedImage
-                  src={getSafeImageUrl(album.images, "sm")}
+                  src={getSafeImageUrl(album.images, "md")}
                   alt={album.name}
                   fill
                   sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, 25vw"


### PR DESCRIPTION
1. [Fix: 아티스트 페이지의 앨범 및 싱글 섹션에서 이미지 사이즈를 md로 설정하도록 변경](https://github.com/jihohub/music-x-music/commit/13a0db53283bf57612b6af84667a0b17a37e8213)